### PR TITLE
Strong tag requirement removed 

### DIFF
--- a/exercises/09-formatting-Text/README.es.md
+++ b/exercises/09-formatting-Text/README.es.md
@@ -8,7 +8,7 @@ HTML estaba destinado a replicar ese comportamiento. Aquí hay un ejemplo de un 
 
 ## 📝 Instrucciones:
 
-1. Escribe el código para replicar exactamente la imagen anterior con los mismos estilos usando html puro, usa headings (encabezados), paragraph (párrafo), strong (negritas), blockquote (citas en bloque), ul y li.
+1. Escribe el código para replicar exactamente la imagen anterior con los mismos estilos usando html puro, usa headings (encabezados), paragraph (párrafo), blockquote (citas en bloque), ul y li.
 
 ## 💡 Pistas:
 

--- a/exercises/09-formatting-Text/README.md
+++ b/exercises/09-formatting-Text/README.md
@@ -12,7 +12,7 @@ HTML was meant to replicate that exact behavior. Here is and example of a typica
 
 ## 📝 Instructions:
 
-1. Please write the code to replicate the exact same styles of the previous image with pure html, use headings, paragraph, strong, blockquote, ul and li.
+1. Please write the code to replicate the exact same styles of the previous image with pure html, use headings, paragraph, blockquote, ul and li.
 
 ## 💡 Hints:
 

--- a/exercises/09-formatting-Text/tests.js
+++ b/exercises/09-formatting-Text/tests.js
@@ -50,11 +50,6 @@ it('<h1> exists', function () {
         expect(document.querySelectorAll("p").length).toBe(3)
     })
 
-
-     it('You should have 1 <strong> tag', function () {
-        expect(document.querySelectorAll("strong").length).toBe(1)
-    })
-
     it('<ul> exist', function () {
         expect(document.querySelectorAll("ul").length).toBeTruthy()
     })


### PR DESCRIPTION
Strong tag cannot be used because the example image does not provide any opportunity for it to be used; therefore, test for strong tag was removed as well as the requirement for it in the instructions.